### PR TITLE
Fix for package dependency

### DIFF
--- a/dbt/Dockerfile
+++ b/dbt/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y && \
 
 # Install DBT
 RUN pip install -U pip
+RUN pip3 install --force-reinstall MarkupSafe==2.0.1
 RUN pip install dbt==0.18.0
 
 # Set environment variables


### PR DESCRIPTION
docker compose fails because of the markupsafe dependency, hence the fix